### PR TITLE
Add caikit tutorial for text classification

### DIFF
--- a/021_caikit_tutorial.ipynb
+++ b/021_caikit_tutorial.ipynb
@@ -1,0 +1,829 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Sentiment Analysis Pipeline in caikit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install caikit transformers requests\n",
+    "# mamba install pytorch cpuonly -c pytorch\n",
+    "# mamba install grpcio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%bash \n",
+    "# pip install caikit[runtime-grpc] -qqq\n",
+    "# pip install caikit[runtime-http] -qqq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Python 3.9.18\n"
+     ]
+    }
+   ],
+   "source": [
+    "!python --version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Name: protobuf\n",
+      "Version: 4.24.4\n",
+      "Summary: \n",
+      "Home-page: https://developers.google.com/protocol-buffers/\n",
+      "Author: protobuf@googlegroups.com\n",
+      "Author-email: protobuf@googlegroups.com\n",
+      "License: 3-Clause BSD License\n",
+      "Location: /home/msivanes/miniconda3/envs/fastchai/lib/python3.9/site-packages\n",
+      "Requires: \n",
+      "Required-by: caikit, grpcio-health-checking, grpcio-reflection, py-to-proto\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip show protobuf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Name: py-to-proto\n",
+      "Version: 0.5.1\n",
+      "Summary: A tool to dynamically create protobuf message classes from python data schemas\n",
+      "Home-page: https://github.com/IBM/py-to-proto\n",
+      "Author: Gabe Goodhart\n",
+      "Author-email: gabe.l.hart@gmail.com\n",
+      "License: MIT\n",
+      "Location: /home/msivanes/miniconda3/envs/fastchai/lib/python3.9/site-packages\n",
+      "Requires: alchemy-logging, protobuf\n",
+      "Required-by: caikit\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip show py-to-proto"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Name: grpcio\n",
+      "Version: 1.59.0\n",
+      "Summary: HTTP/2-based RPC framework\n",
+      "Home-page: https://grpc.io\n",
+      "Author: The gRPC Authors\n",
+      "Author-email: grpc-io@googlegroups.com\n",
+      "License: Apache License 2.0\n",
+      "Location: /home/msivanes/miniconda3/envs/fastchai/lib/python3.9/site-packages\n",
+      "Requires: \n",
+      "Required-by: caikit, grpcio-health-checking, grpcio-reflection, py-grpc-prometheus\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip show grpcio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Outline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Data Module\n",
+    "- Module\n",
+    "- config\n",
+    "- Runtime\n",
+    "- Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Text Classification Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/msivanes/.local/lib/python3.9/site-packages/fastprogress/fastprogress.py:102: UserWarning: Couldn't import ipywidgets properly, progress bar will use console behavior\n",
+      "  warn(\"Couldn't import ipywidgets properly, progress bar will use console behavior\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fastcore.all import *\n",
+    "import warnings; warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Requirements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting requirements-caikit.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile requirements-caikit.txt\n",
+    "\n",
+    "caikit[runtime-grpc, runtime-http]\n",
+    "\n",
+    "# Only needed for HuggingFace\n",
+    "scipy\n",
+    "# torch\n",
+    "# transformers~=4.27.2\n",
+    "\n",
+    "# For http client\n",
+    "requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data Module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Path('./text_sentiment/data_model').mkdir(exist_ok=True, parents=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/data_model/classification.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./text_sentiment/data_model/classification.py\n",
+    "\n",
+    "from typing import List\n",
+    "from caikit.core import DataObjectBase\n",
+    "\n",
+    "from caikit.core.data_model import dataobject\n",
+    "\n",
+    "# A DataObject is a data model class that is backed by a @dataclass. \n",
+    "@dataobject(package=\"text_sentiment.data_model\")\n",
+    "class ClassInfo(DataObjectBase):\n",
+    "    class_name: str\n",
+    "    conf: float\n",
+    "@dataobject(package=\"text_sentiment.data_model\")\n",
+    "class ClassificationPrediction(DataObjectBase):\n",
+    "    classes: List[ClassInfo]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/data_model/__init__.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./text_sentiment/data_model/__init__.py\n",
+    "\n",
+    "from .classification import ClassificationPrediction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Runtime Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Path('./text_sentiment/runtime_model').mkdir(exist_ok=True, parents=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/runtime_model/hf_module.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./text_sentiment/runtime_model/hf_module.py\n",
+    "\n",
+    "from caikit.core import ModuleBase, ModuleLoader, ModuleSaver, TaskBase, task, module\n",
+    "from text_sentiment.data_model.classification import ClassificationPrediction, ClassInfo\n",
+    "from transformers import pipeline\n",
+    "\n",
+    "@task(required_parameters={\"text_input\": str},output_type=ClassificationPrediction)\n",
+    "class HFSentimentTask(TaskBase): pass # defines input args and output type for task\n",
+    "\n",
+    "@module('8f72161-c0e4-49b0-8fd0-7587b3017a35', 'HFSentimentModule', '0.0.1', HFSentimentTask)\n",
+    "class HFSentimentModule(ModuleBase): # inherits from ModuleBase and wraps the sentiment analysis pipeline from HF\n",
+    "    def __init__(self, model_path) -> None:\n",
+    "        super().__init__()\n",
+    "        loader = ModuleLoader(model_path) # loads the model from the path\n",
+    "        config = loader.config # gets the config from the model\n",
+    "        model = pipeline(model=config.hf_artifact_path, task='sentiment-analysis')\n",
+    "        self.sentiment_pipeline = model # sets the pipeline as an attribute of the module\n",
+    "        \n",
+    "    def run(self, text_input: str)->ClassificationPrediction:\n",
+    "        raw_results = self.sentiment_pipeline([text_input]) # runs the pipeline on the input text\n",
+    "        class_info = []\n",
+    "        for result in raw_results: \n",
+    "            class_info.append(ClassInfo(class_name=result['label'], conf=result['score'])) # creates a ClassInfo object for each result\n",
+    "        return ClassificationPrediction(classes=class_info) # returns a ClassificationPrediction object\n",
+    "    \n",
+    "    @classmethod\n",
+    "    def bootstrap(cls, model_path='distilbert-base-uncased-finetuned-sst-2-english'): # classmethod to load a HF based caikit model\n",
+    "        return cls(model_path=model_path)\n",
+    "    \n",
+    "    def save(self, model_path, **kwargs):\n",
+    "        import os\n",
+    "        module_saver = ModuleSaver(self, model_path=model_path) # saving modules and context manager for cleaning up after saving\n",
+    "        with module_saver:\n",
+    "            rel_path, _ = module_saver.add_dir(\"hf_model\")\n",
+    "            save_path = os.path.join(model_path, rel_path)\n",
+    "            self.sentiment_pipeline.save_pretrained(save_path)\n",
+    "            module_saver.update_config({\"hf_artifact_path\": rel_path})\n",
+    "    \n",
+    "    @classmethod\n",
+    "    def load(cls, model_path): # classmethod to load a HF based caikit model\n",
+    "        return cls(model_path=model_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/runtime_model/__init__.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./text_sentiment/runtime_model/__init__.py\n",
+    "\n",
+    "from .hf_module import HFSentimentModule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/config.yml\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./text_sentiment/config.yml\n",
+    "\n",
+    "runtime:\n",
+    "    library: text_sentiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Path('./models/text_sentiment').mkdir(exist_ok=True, parents=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./models/text_sentiment/config.yml\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./models/text_sentiment/config.yml\n",
+    "\n",
+    "module_id: 8f72161-c0e4-49b0-8fd0-7587b3017a35\n",
+    "name: HFSentimentModule\n",
+    "version: 0.0.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Runtime\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Kill the process using a particular port\n",
+    "# !lsof -ti tcp:8086 | xargs kill -9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !lsof -ti tcp:8086"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting start_runtime.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile start_runtime.py\n",
+    "\n",
+    "from os import path\n",
+    "import sys\n",
+    "import alog\n",
+    "from caikit.runtime.__main__ import main\n",
+    "import caikit\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    models_directory = path.abspath(path.join(path.dirname(__file__), \"models\"))\n",
+    "    # models_directory = path.abspath(path.join(path.dirname('.'), \"models\"))\n",
+    "    caikit.config.configure(config_dict=dict(\n",
+    "        merge_strategy=\"merge\", runtime=dict(\n",
+    "            local_models_dir=models_directory, library=\"text_sentiment\", grpc=dict(enabled=True), http=dict(enabled=True)\n",
+    "        )\n",
+    "    ))\n",
+    "    sys.path.append(path.abspath(path.join(path.dirname(__file__), \"../\")))\n",
+    "    alog.configure(default_level=\"debug\")\n",
+    "    main()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/__init__.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./text_sentiment/__init__.py\n",
+    "\n",
+    "from os import path\n",
+    "from . import data_model, runtime_model\n",
+    "import caikit\n",
+    "\n",
+    "CONFIG_PATH = path.realpath(path.join(path.dirname(__file__), \"config.yml\"))\n",
+    "caikit.configure(CONFIG_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./client.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile ./client.py\n",
+    "\n",
+    "from caikit.config.config import get_config # interacts with config.yml\n",
+    "from caikit.runtime import get_inference_request # return the inference request DataModel for the Module or Task Class \n",
+    "from caikit.runtime.service_factory import ServicePackageFactory\n",
+    "from text_sentiment.runtime_model.hf_module import HFSentimentModule\n",
+    "import caikit, grpc, requests, json\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    caikit.config.configure(\n",
+    "        config_dict=dict(merge_strategy='merge',\n",
+    "                        runtime=dict(library='text_sentiment', grpc=dict(enabled=True), http=dict(enabled=True)),)\n",
+    "    )\n",
+    "    inference_service = ServicePackageFactory.get_service_package(\n",
+    "        ServicePackageFactory.ServiceType.INFERENCE\n",
+    "    ) # ServicePackage: A container with properties referencing everything you need to bind a concrete Servicer implementation to a protobufs Service and grpc Server\n",
+    "\n",
+    "    model_id = 'text_sentiment'\n",
+    "\n",
+    "    if get_config().runtime.grpc.enabled:\n",
+    "        # setup grpc client\n",
+    "        port = 8085\n",
+    "        channel= grpc.insecure_channel(f'localhost:{port}')\n",
+    "        client_stub = inference_service.stub_class(channel)\n",
+    "        \n",
+    "        for text in ['I am not feeling well today', 'Today is a nice sunny day']:\n",
+    "            request = get_inference_request(task_or_module_class=HFSentimentModule.TASK_CLASS)(text_input=text).to_proto()\n",
+    "            response = client_stub.HFSentimentTaskPredict(request, \n",
+    "                                                        metadata=[('mm-model-id', model_id)],\n",
+    "                                                        timeout=1)\n",
+    "            print('Text: ', text)\n",
+    "            print('Response from gRPC: ', response)\n",
+    "            \n",
+    "    if get_config().runtime.http.enabled:\n",
+    "        port = 8080\n",
+    "        for text in ['I am not feeling well today', 'Today is a nice sunny day']:\n",
+    "            payload = {\"inputs\": text}\n",
+    "            response = requests.post(\n",
+    "                f\"http://localhost:{port}/api/v1/{model_id}/task/hugging-face-sentiment\",\n",
+    "                json=payload,\n",
+    "                timeout=1,\n",
+    "            )\n",
+    "            print(\"\\nText:\", text)\n",
+    "            \n",
+    "            print(\"RESPONSE from HTTP:\", json.dumps(response.json(), indent=4))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the dependencies\n",
+    "# %pip install -r requirements-caikit.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2023-10-11T19:31:54.001360 [RUNTI:DBUG] Starting up caikit.runtime.grpc_server\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:54.002445\"}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.146893\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.147143\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.150158\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.150415\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.150619\"}\n",
+      "{\"channel\": \"SERVR-BASE\", \"exception\": null, \"level\": \"info\", \"message\": \"Serving prometheus metrics on port 8086\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.159136\"}\n",
+      "{\"channel\": \"SERVR-BASE\", \"duration\": 0.000965, \"exception\": null, \"level\": \"info\", \"message\": \"Booted metrics server in 0:00:00.000965\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.160462\"}\n",
+      "{\"channel\": \"SERVR-GRPC\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN20247875I>\", \"message\": \"Enabling gRPC inference service\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.160736\"}\n",
+      "{\"channel\": \"MODEL-MANAGR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN44739400I>\", \"message\": \"Loading local models into Caikit Runtime...\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.160967\"}\n",
+      "{\"channel\": \"MODEL-LOADER\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN89711114I>\", \"message\": \"Loading model 'text_sentiment'\", \"num_indent\": 0, \"thread_id\": 139674207119040, \"timestamp\": \"2023-10-11T19:31:56.161547\"}\n",
+      "No model was supplied, defaulted to distilbert-base-uncased-finetuned-sst-2-english and revision af0f99b (https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english).\n",
+      "Using a pipeline without specifying a model name and revision in production is not recommended.\n",
+      "{\"channel\": \"MODEL-SIZER\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN62161564I>\", \"message\": \"No configured model size multiplier found for model type 'standalone-model' for model 'text_sentiment'. Using default multiplier '10.000000'\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.164970\"}\n",
+      "{\"channel\": \"MODEL-LOADER\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN89713784I>\", \"message\": \"Singleton cache: '{}'\", \"num_indent\": 0, \"thread_id\": 139674207119040, \"timestamp\": \"2023-10-11T19:31:57.266643\"}\n",
+      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773776I>\", \"message\": \"Metering is disabled, to enable set `metering.enabled` in config to true\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.266932\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.267775\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.268160\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.268543\"}\n",
+      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773778I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.269066\"}\n",
+      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed inference service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.271736\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN81194024I>\", \"message\": \"Intercepting RPC method /caikit.runtime.TextSentiment.TextSentimentService/HFSentimentTaskPredict\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.271912\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Predict\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.272161\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN30032825I>\", \"message\": \"Re-routing RPC /caikit.runtime.TextSentiment.TextSentimentService/HFSentimentTaskPredict from <function _ServiceBuilder._GenerateNonImplementedMethod.<locals>.<lambda> at 0x7f08a72750d0> to <function CaikitRuntimeServerWrapper.safe_rpc_wrapper.<locals>.safe_rpc_call at 0x7f088c7f83a0>\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.272274\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN24924908I>\", \"message\": \"Interception of service caikit.runtime.TextSentiment.TextSentimentService complete\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.272388\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.273178\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.273324\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.273444\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274275\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274410\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274530\"}\n",
+      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773777I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274713\"}\n",
+      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed train service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.277175\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN24924908I>\", \"message\": \"Interception of service caikit.runtime.TextSentiment.TextSentimentTrainingService complete\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.277438\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.278230\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.278378\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.278502\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279307\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279449\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279577\"}\n",
+      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773777I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279748\"}\n",
+      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed train service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.281885\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Run\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.282108\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for GetTrainingStatus\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.282831\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for CancelTraining\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.282958\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for loadModel\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283214\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for unloadModel\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283315\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for predictModelSize\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283408\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for modelSize\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283508\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for runtimeStatus\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283602\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Check\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283872\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Watch\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283986\"}\n",
+      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for ServerReflectionInfo\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.284211\"}\n",
+      "{\"channel\": \"SERVR-GRPC\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN10001807I>\", \"message\": \"Running in insecure mode\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.284411\"}\n",
+      "{\"channel\": \"SERVR-GRPC\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN10001001I>\", \"message\": \"Caikit Runtime is serving on port: 8085 with thread pool size: 5\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.286244\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.950355\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.950501\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.950626\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.953076\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.953256\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.953361\"}\n",
+      "{\"channel\": \"SERVR-HTTP\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN77183426I>\", \"message\": \"Enabling HTTP inference service\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954294\"}\n",
+      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773776I>\", \"message\": \"Metering is disabled, to enable set `metering.enabled` in config to true\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954388\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954874\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954956\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.955055\"}\n",
+      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773778I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.955186\"}\n",
+      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed inference service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.956769\"}\n",
+      "{\"channel\": \"SERVR-HTTP\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN77183427I>\", \"message\": \"Enabling HTTP training service\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.961929\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.962474\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.962572\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.962641\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963095\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963173\"}\n",
+      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963237\"}\n",
+      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773777I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963365\"}\n",
+      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed train service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.964753\"}\n",
+      "{\"channel\": \"SERVR-HTTP\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN10539515I>\", \"message\": \"Running INSECURE\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.965658\"}\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Started server process [325801]\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.987352\"}\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Waiting for application startup.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.987473\"}\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Application startup complete.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.987674\"}\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.988270\"}\n",
+      "{\"channel\": \"uvicorn.access\", \"exception\": null, \"level\": \"info\", \"message\": \"127.0.0.1:50202 - \\\"POST /api/v1/text_sentiment/task/hugging-face-sentiment HTTP/1.1\\\" 404\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:10.812528\"}\n",
+      "{\"channel\": \"uvicorn.access\", \"exception\": null, \"level\": \"info\", \"message\": \"127.0.0.1:50214 - \\\"POST /api/v1/text_sentiment/task/hugging-face-sentiment HTTP/1.1\\\" 404\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:10.818543\"}\n",
+      "^C\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Shutting down\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.076048\"}\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Waiting for application shutdown.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.176775\"}\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Application shutdown complete.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.177165\"}\n",
+      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Finished server process [325801]\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.177371\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Running the caikit runtime\n",
+    "!python start_runtime.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## fin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'config_files': '',\n",
+       " 'merge_strategy': 'merge',\n",
+       " 'enable_error_checks': True,\n",
+       " 'max_exception_log_messages': 4,\n",
+       " 'model_management': {'trainers': {'default': {'type': 'LOCAL',\n",
+       "    'import_class': None,\n",
+       "    'config': {'retention_duration': '1d',\n",
+       "     'use_subprocess': False,\n",
+       "     'subprocess_start_method': 'spawn'}}},\n",
+       "  'finders': {'default': {'type': 'LOCAL', 'config': {'load_path': None}}},\n",
+       "  'initializers': {'default': {'type': 'LOCAL',\n",
+       "    'config': {'backend_priority': [{'type': 'LOCAL'}]}}}},\n",
+       " 'log': {'level': 'info',\n",
+       "  'filters': 'botocore:off,urllib3:off,matplotlib:off,boto3:off,jnius.reflect:off',\n",
+       "  'channel_width': 12,\n",
+       "  'thread_id': True,\n",
+       "  'formatter': 'json'},\n",
+       " 'data_streams': {'file_source_base': None},\n",
+       " 'runtime': {'library': 'sample_lib',\n",
+       "  'local_models_dir': 'models',\n",
+       "  'lazy_load_local_models': False,\n",
+       "  'lazy_load_poll_period_seconds': 10,\n",
+       "  'lazy_load_retries': 2,\n",
+       "  'load_threads': None,\n",
+       "  'tls': {'server': {'key': '', 'cert': ''}, 'client': {'cert': ''}},\n",
+       "  'grpc': {'enabled': True,\n",
+       "   'port': 8085,\n",
+       "   'server_thread_pool_size': 5,\n",
+       "   'server_shutdown_grace_period_seconds': 45,\n",
+       "   'unix_socket_path': '/tmp/mmesh/grpc.sock',\n",
+       "   'options': {}},\n",
+       "  'http': {'enabled': True,\n",
+       "   'port': 8080,\n",
+       "   'route_prefix': 'api/v1',\n",
+       "   'server_shutdown_grace_period_seconds': 5},\n",
+       "  'metrics': {'enabled': True, 'port': 8086},\n",
+       "  'use_abortable_threads': True,\n",
+       "  'service_generation': {'enable_inference': True,\n",
+       "   'enable_training': True,\n",
+       "   'module_guids': {'included': [], 'excluded': []},\n",
+       "   'task_types': {'included': [], 'excluded': []}},\n",
+       "  'batching': {'default': {'size': 0, 'collect_delay_s': 0.0},\n",
+       "   'fake_batch_module': {'size': 10}},\n",
+       "  'metering': {'enabled': False,\n",
+       "   'log_dir': 'metering_logs',\n",
+       "   'log_interval': 3600},\n",
+       "  'training': {'output_dir': 'training_output', 'save_with_id': True}},\n",
+       " 'inference_plugin': {'model_mesh': {'runtime_version': 'real',\n",
+       "   'numeric_runtime_version': 0,\n",
+       "   'capacity': 10737418240,\n",
+       "   'max_loading_concurrency': 2,\n",
+       "   'model_loading_timeout_ms': 121000,\n",
+       "   'latency_based_autoscaling_enabled': True,\n",
+       "   'max_model_concurrency': 2,\n",
+       "   'max_model_concurrency_per_type': {'keywords_text-rank': 8},\n",
+       "   'default_model_size': 18874368,\n",
+       "   'default_model_size_multiplier': 10,\n",
+       "   'model_size_multipliers': {'categories_esa': 2.95,\n",
+       "    'concepts_alchemy': 13,\n",
+       "    'entities_alchemy-disambig': 13.76,\n",
+       "    'entity-mentions_bilstm': 1.44,\n",
+       "    'entity-mentions_rbr': 1.8,\n",
+       "    'sentiment_cnn': 2.73,\n",
+       "    'syntax_izumo': 43000,\n",
+       "    'fake_module': 2}}},\n",
+       " 'libraries': {'sample_lib': {'version': '1.2.3',\n",
+       "   'module_path': 'sample_lib'}}}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from caikit.config.config import get_config\n",
+    "get_config()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/021_caikit_tutorial.ipynb
+++ b/021_caikit_tutorial.ipynb
@@ -21,6 +21,7 @@
    "outputs": [],
    "source": [
     "# %pip install caikit transformers requests\n",
+    "# Install mamba using https://mamba.readthedocs.io/en/latest/mamba-installation.html#mamba-install\n",
     "# mamba install pytorch cpuonly -c pytorch\n",
     "# mamba install grpcio"
    ]
@@ -32,6 +33,7 @@
    "outputs": [],
    "source": [
     "# %%bash \n",
+    "# pip install fastcore\n",
     "# pip install caikit[runtime-grpc] -qqq\n",
     "# pip install caikit[runtime-http] -qqq"
    ]

--- a/021_caikit_tutorial.ipynb
+++ b/021_caikit_tutorial.ipynb
@@ -40,36 +40,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Python 3.9.18\n"
+     ]
+    }
+   ],
    "source": [
     "!python --version"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip show protobuf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip show py-to-proto"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip show grpcio"
    ]
   },
   {
@@ -118,7 +99,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting requirements-caikit.txt\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile requirements-caikit.txt\n",
     "\n",
@@ -153,7 +142,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/data_model/classification.py\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./text_sentiment/data_model/classification.py\n",
     "\n",
@@ -176,7 +173,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/data_model/__init__.py\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./text_sentiment/data_model/__init__.py\n",
     "\n",
@@ -203,7 +208,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/runtime_model/hf_module.py\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./text_sentiment/runtime_model/hf_module.py\n",
     "\n",
@@ -252,7 +265,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/runtime_model/__init__.py\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./text_sentiment/runtime_model/__init__.py\n",
     "\n",
@@ -270,7 +291,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/config.yml\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./text_sentiment/config.yml\n",
     "\n",
@@ -291,7 +320,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./models/text_sentiment/config.yml\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./models/text_sentiment/config.yml\n",
     "\n",
@@ -330,7 +367,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting start_runtime.py\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile start_runtime.py\n",
     "\n",
@@ -357,7 +402,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./text_sentiment/__init__.py\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./text_sentiment/__init__.py\n",
     "\n",
@@ -380,7 +433,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./client.py\n"
+     ]
+    }
+   ],
    "source": [
     "%%writefile ./client.py\n",
     "\n",
@@ -446,7 +507,7 @@
    "outputs": [],
    "source": [
     "# Running the caikit runtime\n",
-    "!python start_runtime.py"
+    "# !python start_runtime.py"
    ]
   },
   {
@@ -463,7 +524,7 @@
    "outputs": [],
    "source": [
     "from caikit.config.config import get_config\n",
-    "get_config()"
+    "# get_config()"
    ]
   },
   {

--- a/021_caikit_tutorial.ipynb
+++ b/021_caikit_tutorial.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,98 +38,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Python 3.9.18\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!python --version"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Name: protobuf\n",
-      "Version: 4.24.4\n",
-      "Summary: \n",
-      "Home-page: https://developers.google.com/protocol-buffers/\n",
-      "Author: protobuf@googlegroups.com\n",
-      "Author-email: protobuf@googlegroups.com\n",
-      "License: 3-Clause BSD License\n",
-      "Location: /home/msivanes/miniconda3/envs/fastchai/lib/python3.9/site-packages\n",
-      "Requires: \n",
-      "Required-by: caikit, grpcio-health-checking, grpcio-reflection, py-to-proto\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip show protobuf"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Name: py-to-proto\n",
-      "Version: 0.5.1\n",
-      "Summary: A tool to dynamically create protobuf message classes from python data schemas\n",
-      "Home-page: https://github.com/IBM/py-to-proto\n",
-      "Author: Gabe Goodhart\n",
-      "Author-email: gabe.l.hart@gmail.com\n",
-      "License: MIT\n",
-      "Location: /home/msivanes/miniconda3/envs/fastchai/lib/python3.9/site-packages\n",
-      "Requires: alchemy-logging, protobuf\n",
-      "Required-by: caikit\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip show py-to-proto"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Name: grpcio\n",
-      "Version: 1.59.0\n",
-      "Summary: HTTP/2-based RPC framework\n",
-      "Home-page: https://grpc.io\n",
-      "Author: The gRPC Authors\n",
-      "Author-email: grpc-io@googlegroups.com\n",
-      "License: Apache License 2.0\n",
-      "Location: /home/msivanes/miniconda3/envs/fastchai/lib/python3.9/site-packages\n",
-      "Requires: \n",
-      "Required-by: caikit, grpcio-health-checking, grpcio-reflection, py-grpc-prometheus\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip show grpcio"
    ]
@@ -161,18 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/msivanes/.local/lib/python3.9/site-packages/fastprogress/fastprogress.py:102: UserWarning: Couldn't import ipywidgets properly, progress bar will use console behavior\n",
-      "  warn(\"Couldn't import ipywidgets properly, progress bar will use console behavior\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from fastcore.all import *\n",
     "import warnings; warnings.filterwarnings('ignore')"
@@ -187,17 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting requirements-caikit.txt\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile requirements-caikit.txt\n",
     "\n",
@@ -221,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,17 +151,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./text_sentiment/data_model/classification.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./text_sentiment/data_model/classification.py\n",
     "\n",
@@ -261,17 +174,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./text_sentiment/data_model/__init__.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./text_sentiment/data_model/__init__.py\n",
     "\n",
@@ -287,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,17 +201,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./text_sentiment/runtime_model/hf_module.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./text_sentiment/runtime_model/hf_module.py\n",
     "\n",
@@ -353,17 +250,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./text_sentiment/runtime_model/__init__.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./text_sentiment/runtime_model/__init__.py\n",
     "\n",
@@ -379,17 +268,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./text_sentiment/config.yml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./text_sentiment/config.yml\n",
     "\n",
@@ -399,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,17 +289,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./models/text_sentiment/config.yml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./models/text_sentiment/config.yml\n",
     "\n",
@@ -436,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,17 +328,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting start_runtime.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile start_runtime.py\n",
     "\n",
@@ -490,17 +355,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./text_sentiment/__init__.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./text_sentiment/__init__.py\n",
     "\n",
@@ -521,17 +378,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting ./client.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile ./client.py\n",
     "\n",
@@ -582,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,112 +441,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2023-10-11T19:31:54.001360 [RUNTI:DBUG] Starting up caikit.runtime.grpc_server\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:54.002445\"}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.146893\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.147143\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.150158\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.150415\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.150619\"}\n",
-      "{\"channel\": \"SERVR-BASE\", \"exception\": null, \"level\": \"info\", \"message\": \"Serving prometheus metrics on port 8086\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.159136\"}\n",
-      "{\"channel\": \"SERVR-BASE\", \"duration\": 0.000965, \"exception\": null, \"level\": \"info\", \"message\": \"Booted metrics server in 0:00:00.000965\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.160462\"}\n",
-      "{\"channel\": \"SERVR-GRPC\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN20247875I>\", \"message\": \"Enabling gRPC inference service\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.160736\"}\n",
-      "{\"channel\": \"MODEL-MANAGR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN44739400I>\", \"message\": \"Loading local models into Caikit Runtime...\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.160967\"}\n",
-      "{\"channel\": \"MODEL-LOADER\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN89711114I>\", \"message\": \"Loading model 'text_sentiment'\", \"num_indent\": 0, \"thread_id\": 139674207119040, \"timestamp\": \"2023-10-11T19:31:56.161547\"}\n",
-      "No model was supplied, defaulted to distilbert-base-uncased-finetuned-sst-2-english and revision af0f99b (https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english).\n",
-      "Using a pipeline without specifying a model name and revision in production is not recommended.\n",
-      "{\"channel\": \"MODEL-SIZER\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN62161564I>\", \"message\": \"No configured model size multiplier found for model type 'standalone-model' for model 'text_sentiment'. Using default multiplier '10.000000'\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:56.164970\"}\n",
-      "{\"channel\": \"MODEL-LOADER\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN89713784I>\", \"message\": \"Singleton cache: '{}'\", \"num_indent\": 0, \"thread_id\": 139674207119040, \"timestamp\": \"2023-10-11T19:31:57.266643\"}\n",
-      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773776I>\", \"message\": \"Metering is disabled, to enable set `metering.enabled` in config to true\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.266932\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.267775\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.268160\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.268543\"}\n",
-      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773778I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.269066\"}\n",
-      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed inference service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.271736\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN81194024I>\", \"message\": \"Intercepting RPC method /caikit.runtime.TextSentiment.TextSentimentService/HFSentimentTaskPredict\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.271912\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Predict\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.272161\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN30032825I>\", \"message\": \"Re-routing RPC /caikit.runtime.TextSentiment.TextSentimentService/HFSentimentTaskPredict from <function _ServiceBuilder._GenerateNonImplementedMethod.<locals>.<lambda> at 0x7f08a72750d0> to <function CaikitRuntimeServerWrapper.safe_rpc_wrapper.<locals>.safe_rpc_call at 0x7f088c7f83a0>\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.272274\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN24924908I>\", \"message\": \"Interception of service caikit.runtime.TextSentiment.TextSentimentService complete\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.272388\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.273178\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.273324\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.273444\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274275\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274410\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274530\"}\n",
-      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773777I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.274713\"}\n",
-      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed train service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.277175\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN24924908I>\", \"message\": \"Interception of service caikit.runtime.TextSentiment.TextSentimentTrainingService complete\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.277438\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.278230\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.278378\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.278502\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279307\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279449\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279577\"}\n",
-      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773777I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.279748\"}\n",
-      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed train service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.281885\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Run\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.282108\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for GetTrainingStatus\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.282831\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for CancelTraining\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.282958\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for loadModel\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283214\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for unloadModel\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283315\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for predictModelSize\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283408\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for modelSize\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283508\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for runtimeStatus\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283602\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Check\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283872\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for Watch\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.283986\"}\n",
-      "{\"channel\": \"SERVER-WRAPR\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN33333123I>\", \"message\": \"Wrapping safe rpc for ServerReflectionInfo\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.284211\"}\n",
-      "{\"channel\": \"SERVR-GRPC\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN10001807I>\", \"message\": \"Running in insecure mode\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.284411\"}\n",
-      "{\"channel\": \"SERVR-GRPC\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN10001001I>\", \"message\": \"Caikit Runtime is serving on port: 8085 with thread pool size: 5\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.286244\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.950355\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.950501\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.950626\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.953076\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.953256\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.953361\"}\n",
-      "{\"channel\": \"SERVR-HTTP\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN77183426I>\", \"message\": \"Enabling HTTP inference service\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954294\"}\n",
-      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773776I>\", \"message\": \"Metering is disabled, to enable set `metering.enabled` in config to true\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954388\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954874\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.954956\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.955055\"}\n",
-      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773778I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.955186\"}\n",
-      "{\"channel\": \"GP-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed inference service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.956769\"}\n",
-      "{\"channel\": \"SERVR-HTTP\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN77183427I>\", \"message\": \"Enabling HTTP training service\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.961929\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.962474\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.962572\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.962641\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: text_sentiment\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963095\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.common\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963173\"}\n",
-      "{\"channel\": \"COM-LIB-INIT\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN11997772I>\", \"message\": \"Loading service module: caikit.interfaces.runtime\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963237\"}\n",
-      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76773777I>\", \"message\": \"Validated Caikit Library CDM successfully\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.963365\"}\n",
-      "{\"channel\": \"GT-SERVICR-I\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN76884779I>\", \"message\": \"Constructed train service for library: text_sentiment, version: unknown\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.964753\"}\n",
-      "{\"channel\": \"SERVR-HTTP\", \"exception\": null, \"level\": \"info\", \"log_code\": \"<RUN10539515I>\", \"message\": \"Running INSECURE\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.965658\"}\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Started server process [325801]\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.987352\"}\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Waiting for application startup.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.987473\"}\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Application startup complete.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.987674\"}\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:31:57.988270\"}\n",
-      "{\"channel\": \"uvicorn.access\", \"exception\": null, \"level\": \"info\", \"message\": \"127.0.0.1:50202 - \\\"POST /api/v1/text_sentiment/task/hugging-face-sentiment HTTP/1.1\\\" 404\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:10.812528\"}\n",
-      "{\"channel\": \"uvicorn.access\", \"exception\": null, \"level\": \"info\", \"message\": \"127.0.0.1:50214 - \\\"POST /api/v1/text_sentiment/task/hugging-face-sentiment HTTP/1.1\\\" 404\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:10.818543\"}\n",
-      "^C\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Shutting down\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.076048\"}\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Waiting for application shutdown.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.176775\"}\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Application shutdown complete.\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.177165\"}\n",
-      "{\"channel\": \"uvicorn.error\", \"exception\": null, \"level\": \"info\", \"message\": \"Finished server process [325801]\", \"num_indent\": 0, \"thread_id\": 139675964474624, \"timestamp\": \"2023-10-11T19:32:20.177371\"}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Running the caikit runtime\n",
     "!python start_runtime.py"
@@ -712,86 +458,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'config_files': '',\n",
-       " 'merge_strategy': 'merge',\n",
-       " 'enable_error_checks': True,\n",
-       " 'max_exception_log_messages': 4,\n",
-       " 'model_management': {'trainers': {'default': {'type': 'LOCAL',\n",
-       "    'import_class': None,\n",
-       "    'config': {'retention_duration': '1d',\n",
-       "     'use_subprocess': False,\n",
-       "     'subprocess_start_method': 'spawn'}}},\n",
-       "  'finders': {'default': {'type': 'LOCAL', 'config': {'load_path': None}}},\n",
-       "  'initializers': {'default': {'type': 'LOCAL',\n",
-       "    'config': {'backend_priority': [{'type': 'LOCAL'}]}}}},\n",
-       " 'log': {'level': 'info',\n",
-       "  'filters': 'botocore:off,urllib3:off,matplotlib:off,boto3:off,jnius.reflect:off',\n",
-       "  'channel_width': 12,\n",
-       "  'thread_id': True,\n",
-       "  'formatter': 'json'},\n",
-       " 'data_streams': {'file_source_base': None},\n",
-       " 'runtime': {'library': 'sample_lib',\n",
-       "  'local_models_dir': 'models',\n",
-       "  'lazy_load_local_models': False,\n",
-       "  'lazy_load_poll_period_seconds': 10,\n",
-       "  'lazy_load_retries': 2,\n",
-       "  'load_threads': None,\n",
-       "  'tls': {'server': {'key': '', 'cert': ''}, 'client': {'cert': ''}},\n",
-       "  'grpc': {'enabled': True,\n",
-       "   'port': 8085,\n",
-       "   'server_thread_pool_size': 5,\n",
-       "   'server_shutdown_grace_period_seconds': 45,\n",
-       "   'unix_socket_path': '/tmp/mmesh/grpc.sock',\n",
-       "   'options': {}},\n",
-       "  'http': {'enabled': True,\n",
-       "   'port': 8080,\n",
-       "   'route_prefix': 'api/v1',\n",
-       "   'server_shutdown_grace_period_seconds': 5},\n",
-       "  'metrics': {'enabled': True, 'port': 8086},\n",
-       "  'use_abortable_threads': True,\n",
-       "  'service_generation': {'enable_inference': True,\n",
-       "   'enable_training': True,\n",
-       "   'module_guids': {'included': [], 'excluded': []},\n",
-       "   'task_types': {'included': [], 'excluded': []}},\n",
-       "  'batching': {'default': {'size': 0, 'collect_delay_s': 0.0},\n",
-       "   'fake_batch_module': {'size': 10}},\n",
-       "  'metering': {'enabled': False,\n",
-       "   'log_dir': 'metering_logs',\n",
-       "   'log_interval': 3600},\n",
-       "  'training': {'output_dir': 'training_output', 'save_with_id': True}},\n",
-       " 'inference_plugin': {'model_mesh': {'runtime_version': 'real',\n",
-       "   'numeric_runtime_version': 0,\n",
-       "   'capacity': 10737418240,\n",
-       "   'max_loading_concurrency': 2,\n",
-       "   'model_loading_timeout_ms': 121000,\n",
-       "   'latency_based_autoscaling_enabled': True,\n",
-       "   'max_model_concurrency': 2,\n",
-       "   'max_model_concurrency_per_type': {'keywords_text-rank': 8},\n",
-       "   'default_model_size': 18874368,\n",
-       "   'default_model_size_multiplier': 10,\n",
-       "   'model_size_multipliers': {'categories_esa': 2.95,\n",
-       "    'concepts_alchemy': 13,\n",
-       "    'entities_alchemy-disambig': 13.76,\n",
-       "    'entity-mentions_bilstm': 1.44,\n",
-       "    'entity-mentions_rbr': 1.8,\n",
-       "    'sentiment_cnn': 2.73,\n",
-       "    'syntax_izumo': 43000,\n",
-       "    'fake_module': 2}}},\n",
-       " 'libraries': {'sample_lib': {'version': '1.2.3',\n",
-       "   'module_path': 'sample_lib'}}}"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from caikit.config.config import get_config\n",
     "get_config()"
@@ -810,18 +479,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This nb is based on the resources found in this comment 

https://github.com/manisnesan/fastchai/issues/57#issue-1938054138


Start the inference server. This serves the gRPC server running at port 8085 and http server running at 8080 
```bash
$ python start_runtime.py
```

Start the client the sends text inputs to gRPC and http (Note: **I am facing issue with http not responding with predictions**). I tried cloning the caikit repository and tried to run the example directly and http is responding withe predictions correctly. So the issue is something to do with the way that I am trying to reproduce the example.

```client
✗ python client.py 
Text:  I am not feeling well today
Response from gRPC:  classes {
  class_name: "NEGATIVE"
  conf: 0.99970537424087524
}

Text:  Today is a nice sunny day
Response from gRPC:  classes {
  class_name: "POSITIVE"
  conf: 0.999869704246521
}


Text: I am not feeling well today
RESPONSE from HTTP: {
    "detail": "Not Found"
}

Text: Today is a nice sunny day
RESPONSE from HTTP: {
    "detail": "Not Found"
}
```

